### PR TITLE
Fix compilation errors for UE 5.3

### DIFF
--- a/Plugins/AnimatedTexturePlugin/Source/AnimatedTexture/Private/AnimatedTextureResource.cpp
+++ b/Plugins/AnimatedTexturePlugin/Source/AnimatedTexture/Private/AnimatedTextureResource.cpp
@@ -46,7 +46,7 @@ static ESamplerAddressMode _ConvertAddressMode(enum TextureAddress addr)
 	return ret;
 }
 
-void FAnimatedTextureResource::InitRHI()
+void FAnimatedTextureResource::InitRHI(FRHICommandListBase& RHICmdList)
 {
 	// Create the sampler state RHI resource.
 	ESamplerAddressMode AddressU = _ConvertAddressMode(Owner->AddressX);
@@ -73,8 +73,7 @@ void FAnimatedTextureResource::InitRHI()
 
 	uint32 NumMips = 1;
 	FString Name = Owner->GetName();
-	FRHIResourceCreateInfo CreateInfo(*Name);
-	TextureRHI = RHICreateTexture2D(GetSizeX(), GetSizeY(), PF_B8G8R8A8, NumMips, 1, Flags, CreateInfo);
+	TextureRHI = RHICreateTexture(FRHITextureCreateDesc::Create2D(*Name, GetSizeX(), GetSizeY(), PF_B8G8R8A8).SetNumMips(NumMips).SetNumSamples(1).SetFlags(Flags));
 	TextureRHI->SetName(Owner->GetFName());
 	RHIUpdateTextureReference(Owner->TextureReference.TextureReferenceRHI, TextureRHI);
 }

--- a/Plugins/AnimatedTexturePlugin/Source/AnimatedTexture/Private/AnimatedTextureResource.h
+++ b/Plugins/AnimatedTexturePlugin/Source/AnimatedTexture/Private/AnimatedTextureResource.h
@@ -27,7 +27,7 @@ public:
 	//~ Begin FTextureResource Interface.
 	virtual uint32 GetSizeX() const override;
 	virtual uint32 GetSizeY() const override;
-	virtual void InitRHI() override;
+	virtual void InitRHI(FRHICommandListBase& RHICmdList) override;
 	virtual void ReleaseRHI() override;
 	//~ End FTextureResource Interface.
 

--- a/Plugins/AnimatedTexturePlugin/Source/AnimatedTextureEditor/Private/AnimatedTextureFactory.cpp
+++ b/Plugins/AnimatedTexturePlugin/Source/AnimatedTextureEditor/Private/AnimatedTextureFactory.cpp
@@ -11,6 +11,7 @@
 #include "AnimatedTextureFactory.h"
 #include "AnimatedTextureEditorModule.h"
 #include "AnimatedTexture2D.h"
+#include "TextureReferenceResolver.h"
 
 #include "Subsystems/ImportSubsystem.h"	// UnrealEd
 #include "EditorFramework/AssetImportData.h"	// Engine


### PR DESCRIPTION
ue5.3 api changes:
- InitRHI requires a command list

ue5.2 api changes:
- RHICreateTexture2D has been deprecated
- FTextureReferenceReplacer moved to new header

Resolves issue #13